### PR TITLE
fixed bugs for dataset generation bug and network structure bug

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/MAPFAST.iml
+++ b/.idea/MAPFAST.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/MAPFAST.iml" filepath="$PROJECT_DIR$/.idea/MAPFAST.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/utils.py
+++ b/utils.py
@@ -93,7 +93,9 @@ class InceptionClassificationNet(nn.Module):
 
 		self.pool2 = nn.MaxPool2d(3, stride=3)
 
-		self.batch = nn.BatchNorm2d(128)
+		self.batch1 = nn.BatchNorm2d(128)
+		self.batch2 = nn.BatchNorm2d(128)
+		self.batch3 = nn.BatchNorm2d(128)
 
 		val = 15488
 		self.linear1 = nn.Linear(val, 200)
@@ -132,7 +134,7 @@ class InceptionClassificationNet(nn.Module):
 		del cov4
 
 		conv = self.pool2(conv)
-		conv = self.batch(conv)
+		conv = self.batch1(conv)
 		conv = F.relu(conv)
 
 		cov1 = self.conv1_(conv)
@@ -150,7 +152,7 @@ class InceptionClassificationNet(nn.Module):
 		del cov4
 
 		conv = self.pool2(conv)
-		conv = self.batch(conv)
+		conv = self.batch2(conv)
 		conv = F.relu(conv)
 
 		cov1 = self.conv1_(conv)
@@ -168,7 +170,7 @@ class InceptionClassificationNet(nn.Module):
 		del cov4
 
 		conv = self.pool2(conv)
-		conv = self.batch(conv)
+		conv = self.batch3(conv)
 		conv = F.relu(conv)
 		conv = conv.view(-1, self.num_features(conv))
 


### PR DESCRIPTION
The dataset split is not working well in the previous version, since the file list fetched from Python is not consistent, so need to sort before shuffling to make sure the split is good.

For testing, it is supposed to use .eval() to switch to the evaluation mode do disable the update of the batch norm.

For the network structure, the previous version is using the same batch norm for different layers, so it will not work in the evaluation mode.